### PR TITLE
Refactor OngoingCall module for greater speed

### DIFF
--- a/lib/telephonist.ex
+++ b/lib/telephonist.ex
@@ -123,7 +123,7 @@ defmodule Telephonist do
       worker(Telephonist.OngoingCall, []),
       worker(Telephonist.Event, []),
       worker(Telephonist.Logger, []),
-      worker(Immortal.EtsTableManager, [Telephonist.OngoingCall], id: Telephonist.OngoingCallTableWatcher),
+      worker(Immortal.ETSTableManager, [Telephonist.OngoingCall, [:named_table, :protected]])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/mix.exs
+++ b/mix.exs
@@ -19,9 +19,8 @@ defmodule Telephonist.Mixfile do
 
   defp deps do
     [
-      {:immortal, "~> 0.0.1"},
+      {:immortal, "~> 0.2.0"},
       {:ex_twiml, "~> 1.1.0"},
-      {:exactor, "~> 2.1.0"},
       {:inch_ex, only: :docs},
       {:ex_doc, only: :docs}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,5 @@
-%{"ex_doc": {:hex, :ex_doc, "0.7.2"},
-  "ex_twiml": {:hex, :ex_twiml, "1.1.1"},
-  "exactor": {:hex, :exactor, "2.1.2"},
-  "immortal": {:hex, :immortal, "0.0.1"},
-  "inch_ex": {:hex, :inch_ex, "0.2.4"},
-  "poison": {:hex, :poison, "1.4.0"}}
+%{"ex_doc": {:hex, :ex_doc, "0.8.4"},
+  "ex_twiml": {:hex, :ex_twiml, "1.1.3"},
+  "immortal": {:hex, :immortal, "0.2.0"},
+  "inch_ex": {:hex, :inch_ex, "0.4.0"},
+  "poison": {:hex, :poison, "1.5.0"}}


### PR DESCRIPTION
Instead of hiding all the ETS operations inside a GenServer, which can
be a bottleneck, this commit runs the lookup operation in the client
process. Save and delete are still inside the GenServer to ensure they
are done sequentially, however, they could be moved outside also.

To accomplish this, the ETS table has to have a name. Also, ExActor
seemed unnecessary for the simple GenServer here, so I removed it also.
