### PR TITLE
Process calls in current process

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,6 @@ progress from there. Existing calls will be looked up in an ETS table managed by
 
 #### Under the Hood
 
-- `CallProcessor.process/3` spins off a new process to do the actual call
-  processing for maximum concurrency.
 - The current state of all ongoing calls is stored in the ETS table managed by
   the `Telephonist.OngoingCall` process. See its docs for more details.
 

--- a/lib/telephonist/call_processor.ex
+++ b/lib/telephonist/call_processor.ex
@@ -1,6 +1,5 @@
 defmodule Telephonist.CallProcessor do
   alias Telephonist.OngoingCall
-  import Task, only: [async: 1, await: 1]
   import Telephonist.Event, only: [notify: 2]
   import Telephonist.Format, only: [atomize_keys: 1]
 
@@ -45,13 +44,8 @@ defmodule Telephonist.CallProcessor do
   def process(machine, twilio, options \\ %{}) do
     twilio = atomize_keys(twilio)
     notify :processing, {machine, twilio, options}
-
-    result = async fn ->
-      call = lookup(twilio)
-      do_processing(call, machine, twilio, options)
-    end
-
-    await result
+    call = lookup(twilio)
+    do_processing(call, machine, twilio, options)
   end
 
   defp lookup(twilio) do


### PR DESCRIPTION
Since `CallProcessor` just `awaits` the result of the `Task` anyway, the
current implementation is actually _slower_. This is because Elixir has
to spin up a new process to handle the call, and then receive the
output. It's much simpler to just handle the call in the current
process, and avoid the overhead of starting a pointless new process.
