### PR TITLE
Make Telephone.Logger more resilient

### DIFF
--- a/lib/telephonist/logger.ex
+++ b/lib/telephonist/logger.ex
@@ -13,13 +13,28 @@ defmodule Telephonist.Logger do
   use GenEvent
   require Logger
 
+  defmodule AddLoggerHandler do
+    @moduledoc """
+    A GenServer which adds Telephonist.Logger handler to Telephonist.Event
+
+    It links to Telephonist.Event, and is supervised (as Telephonist.Logger)
+    so that if the manager should die, this GenServer will too, and the
+    handler will be re-added when they restart.
+    """
+    use GenServer
+
+    def init(_) do
+      true = Process.whereis(Telephonist.Event) |> Process.link
+      :ok = GenEvent.add_handler(Telephonist.Event, Telephonist.Logger, [])
+      {:ok, nil}
+    end
+  end
+
   @doc """
   Start the `Telephonist.Logger` process.
   """
   def start_link do
-    handler = GenEvent.start_link(name: __MODULE__)
-    GenEvent.add_handler(Telephonist.Event, Telephonist.Logger, [])
-    handler
+    GenServer.start_link(AddLoggerHandler, nil)
   end
 
   @doc false


### PR DESCRIPTION
This PR makes `Telephonist.Logger.start_link` start a GenServer which will add `Logger` to `Event`.

The GenServer links to `Event`, so that if it dies, the GenServer will be restarted by the application supervisor, and re-add the handler.

Not really a must-have, but it does more than the current GenEvent in `Logger`, and I just implemented this for my project, so I figured I'd share.
