### PR TITLE
Rename State.options to State.data

### DIFF
--- a/lib/telephonist/state.ex
+++ b/lib/telephonist/state.ex
@@ -1,6 +1,4 @@
 defmodule Telephonist.State do
-  import ExTwiml
-
   @moduledoc """
   `#{__MODULE__}` represents a given state for an ongoing phone call.
 
@@ -8,7 +6,8 @@ defmodule Telephonist.State do
 
   - `name`: the name of the state.
   - `machine`: the module name of the state machine the state is a part of.
-  - `options`: the custom options that were passed to this state.
+  - `data`: any custom data about the call that you want to store between
+    Twilio requests.
   - `twiml`: the TwiML representation of the state.
 
   ## Example
@@ -16,23 +15,25 @@ defmodule Telephonist.State do
       %Telephonist.State{
         name: "introduction",
         machine: IntroductionMachine,
-        options: %{
+        data: %{
           language: "en"
         },
         twiml: "<?xml ..."
       }
   """
 
+  import ExTwiml
+
   @type t :: %__MODULE__{
                name: atom,
                machine: atom,
-               options: map,
+               data: map,
                twiml: String.t
              }
 
   defstruct name: nil,
             machine: nil,
-            options: %{},
+            data: %{},
             twiml: nil
 
   @doc "Returns a 'complete' state, with data from a given state"
@@ -42,7 +43,7 @@ defmodule Telephonist.State do
     %__MODULE__{
       name: :complete,
       machine: state.machine,
-      options: state.options || %{},
+      data: state.data || %{},
       twiml: twiml
     }
   end
@@ -51,7 +52,7 @@ end
 defimpl Inspect, for: Telephonist.State do
   def inspect(state, _opts) do
     data =
-      [state.machine, state.name, state.options state.twiml]
+      [state.machine, state.name, state.data, state.twiml]
       |> Enum.join(", ")
     "#Telephonist.State<#{data}>"
   end

--- a/test/telephonist/call_processor_test.exs
+++ b/test/telephonist/call_processor_test.exs
@@ -6,34 +6,34 @@ defmodule Telephonist.CallProcessorTest do
   defmodule TestMachine do
     use Telephonist.StateMachine, initial_state: :introduction
 
-    state :introduction, _twilio, _options do
+    state :introduction, _twilio, _data do
       say "Hello there!"
     end
 
-    state :english, _twilio, _options do
+    state :english, _twilio, _data do
       say "I speak English!"
     end
 
-    state :spanish, _twilio, _options do
+    state :spanish, _twilio, _data do
       say "I speak Espanol!"
     end
 
-    state :secret, _twilio, _options do
+    state :secret, _twilio, _data do
       say "Secret!"
     end
 
-    def transition(:introduction, %{"Digits" => "1"} = twilio, options) do
-      state(:english, twilio, options)
+    def transition(:introduction, %{"Digits" => "1"} = twilio, data) do
+      state(:english, twilio, data)
     end
 
-    def transition(:introduction, %{"Digits" => "2"} = twilio, options) do
-      state(:spanish, twilio, options)
+    def transition(:introduction, %{"Digits" => "2"} = twilio, data) do
+      state(:spanish, twilio, data)
     end
 
     def on_complete(_, _, _), do: :ok
 
-    def on_transition_error(_, _, twilio, options) do
-      state(:secret, twilio, options)
+    def on_transition_error(_, _, twilio, data) do
+      state(:secret, twilio, data)
     end
   end
 
@@ -47,7 +47,7 @@ defmodule Telephonist.CallProcessorTest do
 
     assert state.machine      == TestMachine
     assert state.name         == :introduction
-    assert state.options.user == "daniel"
+    assert state.data.user == "daniel"
     assert state.twiml        =~ ~r/Hello/
     assert_saved_state  "test", state
     assert_saved_status "test", "in-progress"
@@ -62,7 +62,7 @@ defmodule Telephonist.CallProcessorTest do
     state = CallProcessor.process(TestMachine, twilio, %{hello: "world!"})
     assert state.machine == TestMachine
     assert state.name    == :complete
-    assert state.options == %{hello: "world!"}
+    assert state.data == %{hello: "world!"}
     assert state.twiml ==
       ~S{<?xml version="1.0" encoding="UTF-8"?><Response></Response>}
   end

--- a/test/telephonist/regression/modify_state_test.exs
+++ b/test/telephonist/regression/modify_state_test.exs
@@ -29,15 +29,15 @@ defmodule Telephonist.Regression.ModifyStateTest do
       say "Your ETA is confirmed to be #{job.eta.confirmed} minutes"
     end
 
-    def transition(:prompt, %{"Digits" => minutes} = twilio, meta) do
-      meta = Map.put(meta, :eta, %{unconfirmed: minutes})
-      state :confirmation, twilio, meta
+    def transition(:prompt, %{"Digits" => minutes} = twilio, data) do
+      data = Map.put(data, :eta, %{unconfirmed: minutes})
+      state :confirmation, twilio, data
     end
 
-    def transition(:confirmation, %{"Digits" => "1"} = twilio, meta) do
-      minutes = meta.eta.unconfirmed
-      meta = %{meta | eta: %{confirmed: minutes}}
-      state :confirmed, twilio, meta
+    def transition(:confirmation, %{"Digits" => "1"} = twilio, data) do
+      minutes = data.eta.unconfirmed
+      data = %{data | eta: %{confirmed: minutes}}
+      state :confirmed, twilio, data
     end
 
     def on_complete(_, _, _), do: :ok

--- a/test/telephonist/state_machine_test.exs
+++ b/test/telephonist/state_machine_test.exs
@@ -12,7 +12,7 @@ defmodule Telephonist.StateMachineTest do
       say "Terrible"
     end
 
-    state :welcome, _twilio, _options do
+    state :welcome, _twilio, _data do
       say "Welcome"
     end
 
@@ -20,14 +20,14 @@ defmodule Telephonist.StateMachineTest do
       say "Call"
     end
 
-    def transition(:welcome, %{Digits: digits} = twilio, options)
+    def transition(:welcome, %{Digits: digits} = twilio, data)
     when byte_size(digits) == 3 do
-      state(:call, twilio, options)
+      state(:call, twilio, data)
     end
 
-    def transition(:welcome, twilio, options) do
-      options = Map.put(options, :error, :terrible)
-      state(:welcome, twilio, options)
+    def transition(:welcome, twilio, data) do
+      data = Map.put(data, :error, :terrible)
+      state(:welcome, twilio, data)
     end
 
     def on_complete(_, _, _), do: :ok
@@ -40,7 +40,7 @@ defmodule Telephonist.StateMachineTest do
   test ":welcome state says 'Welcome' if there are no errors" do
     state = TestMachine.state(:welcome, %{}, %{option: "val"})
     assert state.twiml =~ ~r/Welcome/
-    assert %{option: "val"} = state.options
+    assert %{option: "val"} = state.data
   end
 
   test ":welcome can differentiate between different types of errors" do
@@ -62,6 +62,6 @@ defmodule Telephonist.StateMachineTest do
   test "transition to :welcome with an error if less than three digits" do
     state = TestMachine.transition(:welcome, %{Digits: "12"}, %{})
     assert state.name == :welcome
-    assert %{error: _msg} = state.options
+    assert %{error: _msg} = state.data
   end
 end


### PR DESCRIPTION
This is a more logical name for it and reflects what it is for.

Closes #13.
