### PR TITLE
BREAKING: Add Telephonist.Call, refactor events

### DIFF
--- a/lib/telephonist/call.ex
+++ b/lib/telephonist/call.ex
@@ -1,0 +1,47 @@
+defmodule Telephonist.Call do
+  @moduledoc ~S"""
+  Represents a call that `Telephonist` is managing.
+
+  ## Attributes
+
+  - `sid`: The Twilio SID of the call.
+
+  - `status`: The Twilio "CallStatus" of the call. A list of all possible
+    statuses [can be found here][0].
+
+  - `state`: The `Telephonist.State` of the call.
+
+  ## Example
+
+      %Telephonist.Call{
+        sid: "CA8f65fe38772ea4c2e1c14a46543142cf",
+        status: "in-progress",
+        state: %Telephonist.State{
+          name: "introduction",
+          machine: StateMachineName,
+          data: %{
+            language: "en"
+          },
+          twiml: "<?xml ..."
+        }
+      }
+
+  [0]: https://www.twilio.com/docs/api/rest/call#call-status-values
+  """
+
+  defstruct sid: nil,
+            status: nil,
+            state: nil
+
+  @type sid :: String.t
+  @type status :: String.t
+  @type t :: %__MODULE__{
+    sid: sid,
+    status: status,
+    state: Telephonist.State.t
+  }
+
+  def new(sid, status) do
+    %__MODULE__{sid: sid, status: status}
+  end
+end

--- a/lib/telephonist/event.ex
+++ b/lib/telephonist/event.ex
@@ -19,7 +19,7 @@ defmodule Telephonist.Event do
 
         # Define callbacks:
 
-        def handle_event({:processing, {machine, twilio, options}}, _state) do
+        def handle_event({:processing, {machine, twilio, data}}, _state) do
           # ...
         end
       end
@@ -32,92 +32,10 @@ defmodule Telephonist.Event do
 
   ## Events
 
-  Telephonist publishes the following events:
+  You can see all of the events currently broadcasted by `Telephonist.Event` in
+  the `Telephonist.Event.event` typespec.
 
-  - `{:processing, {state_machine, twilio, options}}`: Fires when
-    `CallProcessor.process/3` is called. The three elements of the second tuple
-    represent the arguments passed to `process/3`.
-
-      - `state_machine`: The module name (atom) of the state machine that should
-        control the progression of the call.
-
-      - `twilio`: A map of parameters passed from Twilio.
-
-      - `options`: A map of options to be passed around with the call as it's
-        processed through the system.
-
-  - `{:lookup_succeeded, {sid, status, state}}`: Fired when the call could be
-    found in the ongoing storage table. The second tuple is the
-    data returned from storage.
-
-      - `sid`: The Twilio SID of the call.
-
-      - `status`: The Twilio status of the call. For example, "in-progress".
-
-      - `state`: The most recent `Telephonist.State` of the call when it was
-        saved to the lookup table.
-
-  - `{:lookup_failed, {sid, status, state}}`: Fired when the call could not be
-    found in the lookup table. This doesn't indicate an error, just that the
-    call will start from the beginning state, rather than progressing from a
-    previous state.
-
-  - `{:completed, {sid, state_machine, twilio, options}}`: Fired when a call is
-    completed. This can happen when the user drops or hangs up.
-
-      - `sid`: The Twilio SID of the phone call.
-
-      - `state_machine`: The module name of the state machine that the call
-        ended on.
-
-      - `twilio`: A map of parameters passed by Twilio.
-
-      - `options`: A map of custom options.
-
-  - `{:transition, {sid, state_machine, state_name, twilio, options}}`: Fired
-    when Telephonist attempts to transition a call to a new state.
-
-      - `sid`: The Twilio SID of the call.
-
-      - `state_machine`: The module name (atom) of the state machine.
-      `transition/3` will be called on this state machine.
-
-      - `state_name`: The name of the current state to be transitioned from.
-
-      - `twilio`: A map of parameters from Twilio.
-
-      - `options`: A map of custom options.
-
-
-  - `{:transition_failed, {sid, exception, state_machine, state_name, twilio,
-                           options}}`:
-    Fired when a transition couldn't take place, usually due to an exception.
-
-      - `sid`: The Twilio SID of the call.
-
-      - `exception`: The exception that caused the transition to fail.
-
-      - `state_machine`: The module name (atom) of the state machine that
-        Telephonist attempted to use to do the transition.
-
-      - `state_name`: The name of the state that Telephonist was trying to
-        transition from.
-
-      - `twilio`: A map of parameters from Twilio.
-
-      - `options`: A map of custom options.
-
-  - `{:new_state, {sid, status, state}}`: Fired when a call successfully
-    transitions to a new state.
-
-      - `sid`: The Twilio SID of the call.
-
-      - `status`: The most recent Twilio status of the call. For example,
-        "in-progress".
-
-      - `state`: The new state of the call.
-
-  In your subscriber, add a `handle_event/2` callback for any of the above
+  In your subscriber, add a `handle_event/2` callback for any of these
   events. You should also add a fallback definition to catch those events you
   don't care about:
 
@@ -125,6 +43,19 @@ defmodule Telephonist.Event do
   """
 
   use GenEvent
+
+  alias Telephonist.Call
+
+  @type twilio :: %{String.t => String.t}
+  @type data :: map
+  @type exception :: struct
+  @type event :: {:processing, {module, twilio, data}}
+               | {:call_found, Call.t}
+               | {:call_not_found, Call.t}
+               | {:completed, Call.t}
+               | {:new_state, Call.t}
+               | {:transition, {Call.t, twilio, data}}
+               | {:transition_failed, {exception, Call.t, twilio, data}}
 
   @doc false
   def start_link do

--- a/lib/telephonist/logger.ex
+++ b/lib/telephonist/logger.ex
@@ -26,31 +26,33 @@ defmodule Telephonist.Logger do
     log twilio["CallSid"], "Processing: #{inspect params}"
   end
 
-  def handle_event({:lookup_succeeded, {sid, status, state}}, _state) do
-    log sid, "Call found in status #{inspect status} and #{inspect state}"
+  def handle_event({:call_found, call}, _state) do
+    log call.sid, """
+    Call found in status #{inspect call.status} and #{inspect call.state}"
+    """
   end
 
-  def handle_event({:lookup_failed, {sid, _, _}}, _state) do
-    log sid, "Call not found"
+  def handle_event({:call_not_found, call}, _state) do
+    log call.sid, "Call not found"
   end
 
-  def handle_event({:completed, {sid, _machine, _twilio, _options}}, _state) do
-    log sid, "Call completed."
+  def handle_event({:completed, call}, _state) do
+    log call.sid, "Call completed"
   end
 
-  def handle_event({:transition, {sid, _state_machine, state_name, _twilio,
-                                  _options}}, _state) do
-    log sid, "Transitioning to #{inspect state_name}"
+  def handle_event({:transition, {call, twilio, _data}}, _state) do
+    log call.sid, """
+    Transitioning on #{inspect call.state.name} in response to #{inspect twilio}
+    """
   end
 
   def handle_event({:transition_failed,
-                    {sid, _exception, _state_machine, state_name,
-                     _twilio, _options}}, _state) do
-    log sid, "Transition to #{inspect state_name} failed!"
+                    {_exception, call, _twilio, _data}}, _state) do
+    log call.sid, "Transition on #{inspect call.state.name} failed!"
   end
 
-  def handle_event({:new_state, {sid, _status, state}}, _state) do
-    log sid, "New state: #{inspect state}"
+  def handle_event({:new_state, call}, _state) do
+    log call.sid, "New state: #{inspect call.state}"
   end
 
   def handle_event(_event, _state), do: {:ok, :not_handled}

--- a/lib/telephonist/state.ex
+++ b/lib/telephonist/state.ex
@@ -26,7 +26,7 @@ defmodule Telephonist.State do
 
   @type t :: %__MODULE__{
                name: atom,
-               machine: atom,
+               machine: module,
                data: map,
                twiml: String.t
              }

--- a/lib/telephonist/storage.ex
+++ b/lib/telephonist/storage.ex
@@ -4,23 +4,20 @@ defmodule Telephonist.Storage do
   be persisted in any kind of backend that implements the behaviour.
   """
 
-  @type sid    :: String.t
-  @type status :: String.t
-  @type call   :: {sid, status, Telephonist.State.t}
   @type error  :: {:error, String.t}
 
   @doc """
   Save an ongoing call to the storage system.
   """
-  @callback save(call) :: :ok | error
+  @callback save(Telephonist.Call.t) :: :ok | error
 
   @doc """
   Load a given call out of the storage system using its SID.
   """
-  @callback find(sid) :: {:ok, call} | error
+  @callback find(Telephonist.Call.sid) :: {:ok, Telephonist.Call.t} | error
 
   @doc """
   Delete a call from the storage system by its SID.
   """
-  @callback delete(sid) :: :ok | error
+  @callback delete(Telephonist.Call.sid) :: :ok | error
 end

--- a/test/telephonist/call_processor_test.exs
+++ b/test/telephonist/call_processor_test.exs
@@ -103,12 +103,12 @@ defmodule Telephonist.CallProcessorTest do
   end
 
   defp assert_saved_status(sid, status) do
-    {:ok, {_sid, saved_status, _state}} = storage.find(sid)
+    {:ok, %{status: saved_status}} = storage.find(sid)
     assert saved_status == status
   end
 
   defp assert_saved_state(sid, state) do
-    {:ok, {_sid, _status, saved_state}} = storage.find(sid)
+    {:ok, %{state: saved_state}} = storage.find(sid)
     assert saved_state == state
   end
 

--- a/test/telephonist/storage/ets_test.exs
+++ b/test/telephonist/storage/ets_test.exs
@@ -1,5 +1,7 @@
 defmodule Telephonist.Storage.ETSTest do
   use ExUnit.Case
+
+  alias Telephonist.Call
   alias Telephonist.Storage.ETS, as: Storage
 
   doctest Telephonist.Storage.ETS


### PR DESCRIPTION
Adds `Telephonist.Call`, a struct to replace the tuple format we were
using previously to handle calls. I like this better and it makes it
easier to reason about the call.

There are two breaking changes in this commit:
- Events that are broadcasted have changed. See the Telephonist.Event
  module.
- `Telephonist.Storage` modules have a new API: they must accept and
  return `Telephonist.Call` structs.
