### PR TITLE
Update to work with Elixir 1.15

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/telephonist.ex
+++ b/lib/telephonist.ex
@@ -115,9 +115,9 @@ defmodule Telephonist do
     children = [
       # Define workers and child supervisors to be supervised
       # worker(Telephonist.Worker, [arg1, arg2, arg3])
-      worker(Telephonist.Event, []),
-      worker(Telephonist.Logger, []),
-      worker(Telephonist.Storage.ETS, [])
+      Telephonist.Event,
+      Telephonist.Logger,
+      Telephonist.Storage.ETS,
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/telephonist/call_processor.ex
+++ b/lib/telephonist/call_processor.ex
@@ -58,7 +58,7 @@ defmodule Telephonist.CallProcessor do
   defp find(twilio) do
     sid = twilio["CallSid"]
 
-    case storage.find(sid) do
+    case storage().find(sid) do
       {:ok, call} ->
         notify :call_found, call
         call
@@ -78,7 +78,7 @@ defmodule Telephonist.CallProcessor do
       |> Telephonist.State.complete
 
     :ok = state.machine.on_complete(call, twilio, state.data)
-    storage.delete(call)
+    storage().delete(call)
 
     call = %{call | state: state}
     notify :completed, call
@@ -90,7 +90,7 @@ defmodule Telephonist.CallProcessor do
     state = get_next_state(call, machine, twilio, data)
     call = %{call | state: state}
 
-    storage.save(call)
+    storage().save(call)
     notify :new_state, call
     state
   end

--- a/lib/telephonist/event.ex
+++ b/lib/telephonist/event.ex
@@ -58,6 +58,14 @@ defmodule Telephonist.Event do
                | {:transition_failed, {exception, Call.t, twilio, data}}
 
   @doc false
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, []}
+    }
+  end
+
+  @doc false
   def start_link do
     GenEvent.start_link(name: __MODULE__)
   end

--- a/lib/telephonist/logger.ex
+++ b/lib/telephonist/logger.ex
@@ -22,6 +22,14 @@ defmodule Telephonist.Logger do
   end
 
   @doc false
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, []}
+    }
+  end
+
+  @doc false
   def handle_event({:processing, {_, twilio, _} = params}, _state) do
     log twilio["CallSid"], "Processing: #{inspect params}"
   end

--- a/lib/telephonist/state.ex
+++ b/lib/telephonist/state.ex
@@ -54,6 +54,6 @@ defimpl Inspect, for: Telephonist.State do
     data =
       [state.machine, state.name, state.data, state.twiml]
       |> Enum.join(", ")
-    "#Telephonist.State<#{data}>"
+    "#Telephonist.State<#{inspect data}>"
   end
 end

--- a/lib/telephonist/state_machine.ex
+++ b/lib/telephonist/state_machine.ex
@@ -156,7 +156,7 @@ defmodule Telephonist.StateMachine do
   It should return a new state. If you `use Telephonist.StateMachine`, the
   default implementation will simply re-raise the exception.
   """
-  @callback on_transition_error(map, state_name, twilio, data) :: :ok
+  @callback on_transition_error(map, state_name, twilio, data) :: Telephonist.State.t
 
   ###
   # Macros

--- a/lib/telephonist/storage/ets.ex
+++ b/lib/telephonist/storage/ets.ex
@@ -74,7 +74,7 @@ defmodule Telephonist.Storage.ETS do
   ##
 
   @doc false
-  def start_link do
+  def start_link(_) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,16 +4,16 @@ defmodule Telephonist.Mixfile do
   def project do
     [app: :telephonist,
      version: "1.0.0-pre",
-     elixir: "~> 1.0",
+     elixir: "~> 1.11",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
-     docs: docs,
-     package: package]
+     deps: deps(),
+     docs: docs(),
+     package: package()]
   end
 
   def application do
-    [applications: [:logger],
+    [extra_applications: [:logger],
      mod: {Telephonist, []}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,14 @@
-%{"dogma": {:hex, :dogma, "0.0.11"},
-  "ex_doc": {:hex, :ex_doc, "0.11.3"},
-  "ex_twiml": {:hex, :ex_twiml, "2.0.1"},
-  "immortal": {:hex, :immortal, "0.2.0"},
-  "inch_ex": {:hex, :inch_ex, "0.4.0"},
-  "poison": {:hex, :poison, "1.5.2"}}
+%{
+  "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
+  "dogma": {:hex, :dogma, "0.1.16", "3c1532e2f63ece4813fe900a16704b8e33264da35fdb0d8a1d05090a3022eef9", [:mix], [{:poison, ">= 2.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm", "8533cb896ea527959923f9c3f08e7083e18ff681388ad7c9a599dd5d28e9085f"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.42", "f23d856f41919f17cd06a493923a722d87a2d684f143a1e663c04a2b93100682", [:mix], [], "hexpm", "6915b6ca369b5f7346636a2f41c6a6d78b5af419d61a611079189233358b8b8b"},
+  "ex_doc": {:hex, :ex_doc, "0.36.1", "4197d034f93e0b89ec79fac56e226107824adcce8d2dd0a26f5ed3a95efc36b1", [:mix], [{:earmark_parser, "~> 1.4.42", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_c, ">= 0.1.0", [hex: :makeup_c, repo: "hexpm", optional: true]}, {:makeup_elixir, "~> 0.14 or ~> 1.0", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1 or ~> 1.0", [hex: :makeup_erlang, repo: "hexpm", optional: false]}, {:makeup_html, ">= 0.1.0", [hex: :makeup_html, repo: "hexpm", optional: true]}], "hexpm", "d7d26a7cf965dacadcd48f9fa7b5953d7d0cfa3b44fa7a65514427da44eafd89"},
+  "ex_twiml": {:hex, :ex_twiml, "2.1.3", "1291af09994cdf6731b4e624ae869c1e093b223ca4fceb1599b0af9d66c1afee", [:mix], [], "hexpm", "f576dc688445afb441b6b3318ba9b09b6feda8aae93de7e1007c0e879a7da787"},
+  "inch_ex": {:hex, :inch_ex, "2.0.0", "24268a9284a1751f2ceda569cd978e1fa394c977c45c331bb52a405de544f4de", [:mix], [{:bunt, "~> 0.2", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "96d0ec5ecac8cf63142d02f16b7ab7152cf0f0f1a185a80161b758383c9399a8"},
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
+  "makeup": {:hex, :makeup, "1.2.1", "e90ac1c65589ef354378def3ba19d401e739ee7ee06fb47f94c687016e3713d1", [:mix], [{:nimble_parsec, "~> 1.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "d36484867b0bae0fea568d10131197a4c2e47056a6fbe84922bf6ba71c8d17ce"},
+  "makeup_elixir": {:hex, :makeup_elixir, "1.0.1", "e928a4f984e795e41e3abd27bfc09f51db16ab8ba1aebdba2b3a575437efafc2", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "7284900d412a3e5cfd97fdaed4f5ed389b8f2b4cb49efc0eb3bd10e2febf9507"},
+  "makeup_erlang": {:hex, :makeup_erlang, "1.0.1", "c7f58c120b2b5aa5fd80d540a89fdf866ed42f1f3994e4fe189abebeab610839", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "8a89a1eeccc2d798d6ea15496a6e4870b75e014d1af514b1b71fa33134f57814"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
+  "poison": {:hex, :poison, "6.0.0", "9bbe86722355e36ffb62c51a552719534257ba53f3271dacd20fbbd6621a583a", [:mix], [{:decimal, "~> 2.1", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "bb9064632b94775a3964642d6a78281c07b7be1319e0016e1643790704e739a2"},
+}

--- a/test/telephonist/call_processor_test.exs
+++ b/test/telephonist/call_processor_test.exs
@@ -103,12 +103,12 @@ defmodule Telephonist.CallProcessorTest do
   end
 
   defp assert_saved_status(sid, status) do
-    {:ok, %{status: saved_status}} = storage.find(sid)
+    {:ok, %{status: saved_status}} = storage().find(sid)
     assert saved_status == status
   end
 
   defp assert_saved_state(sid, state) do
-    {:ok, %{state: saved_state}} = storage.find(sid)
+    {:ok, %{state: saved_state}} = storage().find(sid)
     assert saved_state == state
   end
 


### PR DESCRIPTION
Make this package compatible with Elixir 1.15+

* Fix deprecated use of Config
* Updated deprecated `worker` child specs
* Updated use of optional parentheses that is no longer supported
* In `Mix.exs` moved `:logger` from `applications` to `extra_applications` - this fixed some mysterious compilation problems with `ExTwiml`